### PR TITLE
Rohbauhöhe korrigieren

### DIFF
--- a/Source/Module/01 BAD main/source.BIM-all-doors/30_3D-Script.gdl
+++ b/Source/Module/01 BAD main/source.BIM-all-doors/30_3D-Script.gdl
@@ -97,7 +97,7 @@ GOSUB "startposition"
 IF dk_wallhole_control THEN
 
 	x = ac_wallhole_width
-	y = ac_wallhole_height
+	y = ac_wallhole_height_original
 
 	! #### Loch schneiden
 	msk = 1+2+4  + 8+16

--- a/Source/Module/01 BAD main/source.BIM-all-doors/40_Parameter-Script.gdl
+++ b/Source/Module/01 BAD main/source.BIM-all-doors/40_Parameter-Script.gdl
@@ -688,7 +688,7 @@ END
 	IF equalize="ja" OR equalize="Ja" OR equalize ="JA" OR \
 	   equalize="an" OR equalize="An" OR equalize ="AN" THEN equalize = yesKey
 	IF equalize="nein" OR equalize="Nein" OR equalize ="NEIN" OR \
-	   equalize="AUS" OR equalize="Aus" OR equalize ="AUS" OR \
+	   equalize="aus" OR equalize="Aus" OR equalize ="AUS" OR \
 	   equalize="-" OR equalize ="" THEN equalize = noKey
 	RETURN
 
@@ -1089,6 +1089,35 @@ END
 
 "CheckBasicSizeSettings":
 
+	! Korrekte Berechnung Rohbauhöhe
+	if ac_wallhole_height_original < EPS then
+		ac_wallhole_height_original = ac_wallhole_height
+		parameters \
+			ac_wallhole_height_original = ac_wallhole_height_original
+	endif
+	if ac_reveal_height_original < EPS then
+		ac_reveal_height_original = ac_reveal_height
+		parameters \
+			ac_reveal_height_original = ac_reveal_height_original
+	endif
+
+	if 	GLOB_MODPAR_NAME = "iHoleUnderThreshold" 	|\
+		GLOB_MODPAR_NAME = "thresholdBottomOversize" \
+	then
+		ac_wallhole_height	= ac_wallhole_height_original + thresholdExtraHole
+		ac_reveal_height	= ac_reveal_height_original + thresholdExtraHole
+		parameters	\
+			ac_wallhole_height	= ac_wallhole_height,
+			ac_reveal_height	= ac_reveal_height
+	else
+		ac_wallhole_height_original	= ac_wallhole_height - thresholdExtraHole
+		ac_reveal_height_original	= ac_reveal_height - thresholdExtraHole
+		parameters	\
+			ac_wallhole_height_original	= ac_wallhole_height_original,
+			ac_reveal_height_original	= ac_reveal_height_original
+	endif
+
+
 	bNominalSelectChanged = 0
 
 	! #### Nominal Size Radio Button: Nominalmaß - Einzelmaß - Richtung der Zuweisung
@@ -1208,9 +1237,9 @@ END
 
 		TotalLeafWidth = ac_leaf_width + gs_SecondLeaf_w *(bs_door_leafs > 1)
 
-		IF gs_wallhole_nominal		then PARAMETERS A = ac_wallhole_width,		B = ac_wallhole_height !- thresholdExtraHole
+		IF gs_wallhole_nominal		then PARAMETERS A = ac_wallhole_width,		B = ac_wallhole_height - thresholdExtraHole
 		IF gs_baurichtmass_nominal	then PARAMETERS A = ac_baurichtmass_width,	B = ac_baurichtmass_height
-		IF gs_reveal_nominal		then PARAMETERS A = ac_reveal_width,		B = ac_reveal_height   !- thresholdExtraHole
+		IF gs_reveal_nominal		then PARAMETERS A = ac_reveal_width,		B = ac_reveal_height   - thresholdExtraHole
 		IF gs_unit_nominal			then PARAMETERS A = ac_unit_width,			B = ac_unit_height
 		IF gs_egress_nominal		then PARAMETERS A = ac_egress_width,		B = ac_egress_height
 		IF dk_FrameRebate_nominal	then PARAMETERS A = bs_FrameRebate_width,	B = bs_FrameRebate_height
@@ -1228,8 +1257,8 @@ END
 			minSize = minUnitWidth  + wallholeDLeft  + wallholeDRight : IF A < minSize THEN : A = minSize : PARAMETERS A = A : ENDIF
 			minSize = minUnitHeight + wallholeDUpper + wallholeDLower : IF B < minSize THEN : B = minSize : PARAMETERS B = B : ENDIF
 			ac_wallhole_width	= A
-			ac_wallhole_height	= B !+ thresholdExtraHole
-			PARAMETERS ac_wallhole_width = A, ac_wallhole_height = B !+ thresholdExtraHole
+			ac_wallhole_height	= B + thresholdExtraHole
+			PARAMETERS ac_wallhole_width = A, ac_wallhole_height = B + thresholdExtraHole
 			iSizeByNominal = 1
 			ENDIF
 
@@ -1246,8 +1275,8 @@ END
 			minSize = minUnitWidth  + wallholeDLeft  + wallholeDRight - revealDLeft  - revealDRight : IF A < minSize THEN : A = minSize : PARAMETERS A = A : ENDIF
 			minSize = minUnitHeight + wallholeDUpper + wallholeDLower - revealDUpper - revealDLower : IF B < minSize THEN : B = minSize : PARAMETERS B = B : ENDIF
 			ac_reveal_width  = A
-			ac_reveal_height = B !+ thresholdExtraHole
-			PARAMETERS ac_reveal_width = A, ac_reveal_height = B !+ thresholdExtraHole
+			ac_reveal_height = B + thresholdExtraHole
+			PARAMETERS ac_reveal_width = A, ac_reveal_height = B + thresholdExtraHole
 			iSizeByNominal = 4
 			ENDIF
 


### PR DESCRIPTION
Die Rohbauhöhe kann jetzt im Grundriss in Bemaßungen korrekt wiedergegeben werden.
Fixes #4 